### PR TITLE
Switch from Apache Tomcat to JBoss Undertow.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,18 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Utilizing the **Undertow** web server as a servlet container instead of **Tomcat** used by default.