### PR TITLE
Implement the routes processing mechanism to search for bus stops occurrences + populate the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ $ curl 'http://localhost:8080/api/direct?from=82&to=35390'
 
 ### Error handling
 
-When the query string passed in a request, contains inappropriate input, or the URI endpoint doesn't contain anything else at all after its path, the microservice will respond with the **HTTP 400 Bad Request** status code, including the response body in JSON representation, like the following:
+When the query string passed in a request, contains inappropriate input, or the URI endpoint doesn't contain anything else at all after its path, the microservice will respond with the **HTTP 400 Bad Request** status code, including a specific response body in JSON representation, like the following:
 
 ```
 $ curl 'http://localhost:8080/api/direct?from=qwerty4838&to=-i-.;--089asdf../nj524987'
 {"error":"Request parameters must take positive integer values, in the range 1 .. 2,147,483,647. Please check your inputs."}
 ```
 
-Or simply:
+Or even simpler:
 
 ```
 $ curl http://localhost:8080/api/direct

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 
 ## Building
 
+The microservice is known to be built and run successfully under **Ubuntu Server (Ubuntu 20.04.3 LTS x86-64)**. Install the necessary dependencies (`openjdk-11-jdk-headless`, `maven`, `make`):
+
+```
+$ sudo apt-get update && \
+  sudo apt-get install openjdk-11-jdk-headless maven make -y
+```
+
 **Build** the microservice using **Maven Wrapper**:
 
 ```
@@ -28,7 +35,7 @@ $ ./mvnw package
 
 (Note: the `package` target above includes `test`.)
 
-**Build** the microservice using **GNU Make**:
+**Build** the microservice using **GNU Make** (optional):
 
 ```
 $ make clean
@@ -71,4 +78,26 @@ $ # Whilst this is not necessary, it's beneficial knowing the exit code.
 
 ## Operating
 
-**TBD**
+All the routes are contained in a so called **routes data store**. It is located in the `data/` directory. The default filename for it is `routes.txt`, but it can be specified explicitly (if intended to use another one) in the `src/main/resources/application.properties` file.
+
+**Identify**, whether there is a direct route between two bus stops with IDs given in the **HTTP GET** request, searching for them against the underlying **routes data store**:
+
+HTTP request param | Sample value | Another sample value
+------------------ | ------------ | --------------------
+`from`             | `4838`       | `82`
+`to`               | `524987`     | `35390`
+
+The direct route is found:
+
+```
+$ curl 'http://localhost:8080/api/direct?from=4838&to=524987'
+{"from":4838,"to":524987,"direct":true}
+
+```
+
+The direct route is not found:
+
+```
+$ curl 'http://radicv144:8080/api/direct?from=82&to=35390'
+{"from":82,"to":35390,"direct":false}
+```

--- a/README.md
+++ b/README.md
@@ -92,12 +92,11 @@ The direct route is found:
 ```
 $ curl 'http://localhost:8080/api/direct?from=4838&to=524987'
 {"from":4838,"to":524987,"direct":true}
-
 ```
 
 The direct route is not found:
 
 ```
-$ curl 'http://radicv144:8080/api/direct?from=82&to=35390'
+$ curl 'http://localhost:8080/api/direct?from=82&to=35390'
 {"from":82,"to":35390,"direct":false}
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * **[Building](#building)**
 * **[Running](#running)**
 * **[Operating](#operating)**
+  * **[Error handling](#error-handling)**
 
 ## Building
 
@@ -99,4 +100,20 @@ The direct route is not found:
 ```
 $ curl 'http://localhost:8080/api/direct?from=82&to=35390'
 {"from":82,"to":35390,"direct":false}
+```
+
+### Error handling
+
+When the query string passed in a request, contains inappropriate input, or the URI endpoint doesn't contain anything else at all after its path, the microservice will respond with the **HTTP 400 Bad Request** status code, including the response body in JSON representation, like the following:
+
+```
+$ curl 'http://localhost:8080/api/direct?from=qwerty4838&to=-i-.;--089asdf../nj524987'
+{"error":"Request parameters must take positive integer values, in the range 1 .. 2,147,483,647. Please check your inputs."}
+```
+
+Or simply:
+
+```
+$ curl http://localhost:8080/api/direct
+{"error":"Request parameters must take positive integer values, in the range 1 .. 2,147,483,647. Please check your inputs."}
 ```

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingApplication.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingApplication.java
@@ -35,6 +35,13 @@ public class UrbanBusRoutingApplication {
     /** The path and filename of the sample routes data store. */
     private static final String SAMPLE_ROUTES = "./data/routes.txt";
 
+    /**
+     * The regex pattern for the element to be excluded
+     * from a bus stops sequence: it is an arbitrary identifier
+     * of a route, which is not used in the routes processing anyhow.
+     */
+    private static final String ROUTE_ID_REGEX = "^\\d+\\s";
+
     /** The list, containing all available routes. */
     public static List<String> routes_list;
 
@@ -62,8 +69,9 @@ public class UrbanBusRoutingApplication {
 
         routes_list = new ArrayList();
 
-        while (routes.hasNext()) {
-            routes_list.add(routes.nextLine());
+        while (routes.hasNextLine()) {
+            routes_list.add(routes.nextLine()
+                .replaceFirst(ROUTE_ID_REGEX, EMPTY_STRING));
         }
 
         routes.close();

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -149,10 +149,9 @@ public class UrbanBusRoutingController {
 
         String route = EMPTY_STRING;
 
-        for (int i = 0;
-                 i < UrbanBusRoutingApplication.routes_list.size();
-                 i++) {
+        int routes_count = UrbanBusRoutingApplication.routes_list.size();
 
+        for (int i = 0; i < routes_count; i++) {
             route = UrbanBusRoutingApplication.routes_list.get(i);
 
             l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -79,17 +79,17 @@ public class UrbanBusRoutingController {
      * @param from The starting bus stop point.
      * @param to   The ending   bus stop point.
      *
-     * @return The ResponseEntity object with a specific
-     *         HTTP status code provided.
+     * @return The ResponseEntity object, containing the response body
+     *         in JSON representation, along with a specific HTTP status code
+     *         provided.
      */
     @GetMapping(REST_PREFIX + SLASH + REST_DIRECT)
     public ResponseEntity get_direct_route(
         @RequestParam(name=FROM, defaultValue=ZERO) final String from,
         @RequestParam(name=TO,   defaultValue=ZERO) final String to) {
 
-        int     from_i = 0;
-        int     to_i   = 0;
-        boolean direct = false;
+        int _from = 0;
+        int _to   = 0;
 
         l.debug(FROM + EQUALS + BRACES + SPACE + V_BAR + SPACE
               + TO   + EQUALS + BRACES,
@@ -102,10 +102,10 @@ public class UrbanBusRoutingController {
         boolean is_request_malformed = false;
 
         try {
-            from_i = Integer.parseInt(from);
-            to_i   = Integer.parseInt(to  );
+            _from = Integer.parseInt(from);
+            _to   = Integer.parseInt(to  );
 
-            if ((from_i < 1) || (to_i < 1)) {
+            if ((_from < 1) || (_to < 1)) {
                 is_request_malformed = true;
             }
         } catch (NumberFormatException e) {
@@ -123,10 +123,31 @@ public class UrbanBusRoutingController {
         // --- Parsing and validating request params - End --------------------
         // --------------------------------------------------------------------
 
-        String route = EMPTY_STRING;
+        // Performing the routes processing to find out the direct route.
+        boolean direct = find_direct_route(String.valueOf(_from),
+                                           String.valueOf(_to  ));
 
-        String from_s = String.valueOf(from_i);
-        String to_s   = String.valueOf(to_i  );
+        UrbanBusRoutingResponsePojo resp_body
+            = new UrbanBusRoutingResponsePojo(_from, _to, direct);
+
+        return new ResponseEntity(resp_body, HttpStatus.OK);
+    }
+
+    /**
+     * Performs the routes processing (onto bus stops sequences) to identify
+     * and return whether a particular interval between two bus stop points
+     * given is direct (i.e. contains in any of the routes), or not.
+     *
+     * @param from The starting bus stop point.
+     * @param to   The ending   bus stop point.
+     *
+     * @return <code>true</code> if the direct route is found,
+     *         <code>false</code> otherwise.
+     */
+    private boolean find_direct_route(final String from, final String to) {
+        boolean direct = false;
+
+        String route = EMPTY_STRING;
 
         for (int i = 0;
                  i < UrbanBusRoutingApplication.routes_list.size();
@@ -136,8 +157,8 @@ public class UrbanBusRoutingController {
 
             l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);
 
-            if (route.matches(SEQ1_REGEX + from_s + SEQ2_REGEX)) {
-                if (route.matches(SEQ1_REGEX + to_s + SEQ2_REGEX)) {
+            if (route.matches(SEQ1_REGEX + from + SEQ2_REGEX)) {
+                if (route.matches(SEQ1_REGEX + to + SEQ2_REGEX)) {
                     direct = true;
 
                     break;
@@ -145,10 +166,7 @@ public class UrbanBusRoutingController {
             }
         }
 
-        UrbanBusRoutingResponsePojo resp_body
-            = new UrbanBusRoutingResponsePojo(from_i, to_i, direct);
-
-        return new ResponseEntity(resp_body, HttpStatus.OK);
+        return direct;
     }
 }
 

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -46,6 +46,18 @@ public class UrbanBusRoutingController {
     // Extra helper constants.
     private static final String ZERO = "0";
 
+    /**
+     * The regex pattern for the leading part of a bus stops sequence,
+     * before the matching element.
+     */
+    private static final String SEQ1_REGEX = ".*\\s";
+
+    /**
+     * The regex pattern for the trailing part of a bus stops sequence,
+     * after the matching element.
+     */
+    private static final String SEQ2_REGEX = "\\s.*";
+
     /** The SLF4J logger. */
     private static final Logger l = LoggerFactory.getLogger(
         MethodHandles.lookup().lookupClass()
@@ -124,8 +136,8 @@ public class UrbanBusRoutingController {
 
             l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);
 
-            if (route.contains(from_s)) {
-                if (route.contains(to_s)) {
+            if (route.matches(SEQ1_REGEX + from_s + SEQ2_REGEX)) {
+                if (route.matches(SEQ1_REGEX + to_s + SEQ2_REGEX)) {
                     direct = true;
 
                     break;

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -75,9 +75,9 @@ public class UrbanBusRoutingController {
         @RequestParam(name=FROM, defaultValue=ZERO) final String from,
         @RequestParam(name=TO,   defaultValue=ZERO) final String to) {
 
-        int     _from   = 0;
-        int     _to     = 0;
-        boolean _direct = false;
+        int     from_i = 0;
+        int     to_i   = 0;
+        boolean direct = false;
 
         l.debug(FROM + EQUALS + BRACES + SPACE + V_BAR + SPACE
               + TO   + EQUALS + BRACES,
@@ -90,10 +90,10 @@ public class UrbanBusRoutingController {
         boolean is_request_malformed = false;
 
         try {
-            _from = Integer.parseInt(from);
-            _to   = Integer.parseInt(to  );
+            from_i = Integer.parseInt(from);
+            to_i   = Integer.parseInt(to  );
 
-            if ((_from < 1) || (_to < 1)) {
+            if ((from_i < 1) || (to_i < 1)) {
                 is_request_malformed = true;
             }
         } catch (NumberFormatException e) {
@@ -113,6 +113,9 @@ public class UrbanBusRoutingController {
 
         String route = EMPTY_STRING;
 
+        String from_s = String.valueOf(from_i);
+        String to_s   = String.valueOf(to_i  );
+
         for (int i = 0;
                  i < UrbanBusRoutingApplication.routes_list.size();
                  i++) {
@@ -121,9 +124,9 @@ public class UrbanBusRoutingController {
 
             l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);
 
-            if (route.contains(from)) {
-                if (route.contains(to)) {
-                    _direct = true;
+            if (route.contains(from_s)) {
+                if (route.contains(to_s)) {
+                    direct = true;
 
                     break;
                 }
@@ -131,7 +134,7 @@ public class UrbanBusRoutingController {
         }
 
         UrbanBusRoutingResponsePojo resp_body
-            = new UrbanBusRoutingResponsePojo(_from, _to, _direct);
+            = new UrbanBusRoutingResponsePojo(from_i, to_i, direct);
 
         return new ResponseEntity(resp_body, HttpStatus.OK);
     }

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -111,12 +111,23 @@ public class UrbanBusRoutingController {
         // --- Parsing and validating request params - End --------------------
         // --------------------------------------------------------------------
 
+        String route = EMPTY_STRING;
+
         for (int i = 0;
                  i < UrbanBusRoutingApplication.routes_list.size();
                  i++) {
 
-            l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES,
-                UrbanBusRoutingApplication.routes_list.get(i));
+            route = UrbanBusRoutingApplication.routes_list.get(i);
+
+            l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);
+
+            if (route.contains(from)) {
+                if (route.contains(to)) {
+                    _direct = true;
+
+                    break;
+                }
+            }
         }
 
         UrbanBusRoutingResponsePojo resp_body


### PR DESCRIPTION
- Excluding route identifiers from the routes processing.
- Implementing the routes processing mechanism to search for bus stops occurrences.
- Making possible treating inputs containing leading or trailing zeros as valid integers.
- **Bugfix:** Utilizing compound regexes instead of bare textual identifiers of bus stops: this is important because bus stop IDs, taken from request parameters, may be contained as part or inside bigger IDs, in a data store.
- 1. Bringing out the routes processing mechanism to a dedicated method.
- 2. Reverting back the leading underscore naming scheme for helper vars.
- 3. Adjusting one Javadoc comment a little.
- Speeding up the routes processing a little.
- Providing information on build dependencies and operating with the service.
- Fixing a typo: making examples as neutral as possible.
- Adding the docs subsection describing error handling.
- Fixing the error handling subsection wording in the docs.