### PR TITLE
Bugfix: Search the ending bus stop point in the forward direction only.

### DIFF
--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingApplication.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingApplication.java
@@ -40,7 +40,7 @@ public class UrbanBusRoutingApplication {
      * from a bus stops sequence: it is an arbitrary identifier
      * of a route, which is not used in the routes processing anyhow.
      */
-    private static final String ROUTE_ID_REGEX = "^\\d+\\s";
+    private static final String ROUTE_ID_REGEX = "^\\d+";
 
     /** The list, containing all available routes. */
     public static List<String> routes_list;
@@ -71,7 +71,7 @@ public class UrbanBusRoutingApplication {
 
         while (routes.hasNextLine()) {
             routes_list.add(routes.nextLine()
-                .replaceFirst(ROUTE_ID_REGEX, EMPTY_STRING));
+                .replaceFirst(ROUTE_ID_REGEX, EMPTY_STRING) + SPACE);
         }
 
         routes.close();

--- a/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
+++ b/src/main/java/com/transroutownish/proto/bus/UrbanBusRoutingController.java
@@ -147,7 +147,7 @@ public class UrbanBusRoutingController {
     private boolean find_direct_route(final String from, final String to) {
         boolean direct = false;
 
-        String route = EMPTY_STRING;
+        String route = EMPTY_STRING, route_from = EMPTY_STRING;
 
         int routes_count = UrbanBusRoutingApplication.routes_list.size();
 
@@ -157,10 +157,16 @@ public class UrbanBusRoutingController {
             l.debug((i + 1) + SPACE + EQUALS + SPACE + BRACES, route);
 
             if (route.matches(SEQ1_REGEX + from + SEQ2_REGEX)) {
-                if (route.matches(SEQ1_REGEX + to + SEQ2_REGEX)) {
-                    direct = true;
+                // Pinning in the starting bus stop point, if it's found.
+                // Next, searching for the ending bus stop point
+                // on the current route, beginning at the pinned point.
+                route_from = route.substring(route.indexOf(from));
 
-                    break;
+                l.debug(BRACES + SPACE + V_BAR + SPACE + BRACES,
+                        from, route_from);
+
+                if (route_from.matches(SEQ1_REGEX + to + SEQ2_REGEX)) {
+                    direct = true; break;
                 }
             }
         }


### PR DESCRIPTION
- Not ignoring the first and last bus stop IDs in a route when searching for a direct route.
- Searching for the ending bus stop point in the **forward direction** only, but not in the backward one, even if there is such.
---
**Fixes** this issue &ndash; #9.