### PR TITLE
Remove stock Maven from the list of build-time dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 
 ## Building
 
-The microservice is known to be built and run successfully under **Ubuntu Server (Ubuntu 20.04.3 LTS x86-64)**. Install the necessary dependencies (`openjdk-11-jdk-headless`, `maven`, `make`):
+The microservice is known to be built and run successfully under **Ubuntu Server (Ubuntu 20.04.3 LTS x86-64)**. Install the necessary dependencies (`openjdk-11-jdk-headless`, `make`):
 
 ```
 $ sudo apt-get update && \
-  sudo apt-get install openjdk-11-jdk-headless maven make -y
+  sudo apt-get install openjdk-11-jdk-headless make -y
 ```
 
 **Build** the microservice using **Maven Wrapper**:


### PR DESCRIPTION
- Having **Maven** is in build-time dependencies _not necessary_, because **Maven Wrapper** is used anyway.